### PR TITLE
Add missing dependency to codicons in opam file

### DIFF
--- a/memtrace_viewer.opam
+++ b/memtrace_viewer.opam
@@ -15,6 +15,7 @@ depends: [
   "async_kernel"
   "async_rpc_kernel"
   "bonsai"
+  "codicons"
   "core_kernel"
   "ppx_jane"
   "async_rpc_websocket"


### PR DESCRIPTION
The opam install failed on my machine because codicons was not installed. This PR adds the dependency to the .opam file.